### PR TITLE
Add new flight component

### DIFF
--- a/apps/fly-my-rockets/src/app/home-page/home-page.component.scss
+++ b/apps/fly-my-rockets/src/app/home-page/home-page.component.scss
@@ -1,6 +1,6 @@
 .card--homepage {
   width: 280px;
-  margin: 24px auto;
+  margin: 0 auto;
 }
 
 @media screen and (min-width: 768px) {

--- a/apps/fly-my-rockets/src/app/rockets/flight-new/flight-new.component.html
+++ b/apps/fly-my-rockets/src/app/rockets/flight-new/flight-new.component.html
@@ -1,0 +1,37 @@
+<form [formGroup]="flightForm" class="flight-form" (ngSubmit)="createFlight()">
+  <legend><h1>New {{(rocket$ | async)?.name}} Flight</h1></legend>
+
+  <mat-form-field>
+    <mat-label>Date</mat-label>
+    <input matInput [matDatepicker]="picker" placeholder="1/1/2020" formControlName="date">
+    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+    <mat-datepicker #picker></mat-datepicker>
+  </mat-form-field>
+  <mat-form-field>
+    <mat-label>Altitude</mat-label>
+    <input type="tel" matInput placeholder="3000" formControlName="altitude">
+  </mat-form-field>
+  <div formArrayName="motors">
+    <div *ngFor="let motor of motors.controls; index as idx">
+      <mat-form-field>
+        <mat-label>Motor {{idx + 1}}</mat-label>
+        <input type="text" matInput [formControlName]="idx">
+        <button type="button" mat-icon-button matSuffix (click)="removeMotor(idx)"
+                *ngIf="motors.length > 1">
+          <mat-icon>delete</mat-icon>
+        </button>
+      </mat-form-field>
+    </div>
+  </div>
+  <button type="button" mat-button (click)="addMotor()">
+    <mat-icon>add</mat-icon> Add Another Motor
+  </button>
+  <mat-form-field>
+    <mat-label>Notes</mat-label>
+    <textarea matInput formControlName="notes"></textarea>
+  </mat-form-field>
+
+  <button type="submit" mat-raised-button color="primary">
+    Save
+  </button>
+</form>

--- a/apps/fly-my-rockets/src/app/rockets/flight-new/flight-new.component.scss
+++ b/apps/fly-my-rockets/src/app/rockets/flight-new/flight-new.component.scss
@@ -1,0 +1,3 @@
+mat-form-field {
+  display: block;
+}

--- a/apps/fly-my-rockets/src/app/rockets/flight-new/flight-new.component.spec.ts
+++ b/apps/fly-my-rockets/src/app/rockets/flight-new/flight-new.component.spec.ts
@@ -1,0 +1,29 @@
+import { FlightNewComponent } from './flight-new.component';
+import { Subject } from 'rxjs';
+import { FormBuilder } from '@angular/forms';
+
+describe('FlightNewComponent', () => {
+  let component: FlightNewComponent;
+  let rocketService;
+  let route;
+  let router;
+  let flightService;
+
+  beforeEach(() => {
+    rocketService = {};
+    route = { paramMap: new Subject() };
+    router = { navigate: jest.fn() };
+    flightService = { createFlight: jest.fn() };
+    component = new FlightNewComponent(
+      new FormBuilder(),
+      rocketService,
+      route,
+      router,
+      flightService
+    );
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/fly-my-rockets/src/app/rockets/flight-new/flight-new.component.ts
+++ b/apps/fly-my-rockets/src/app/rockets/flight-new/flight-new.component.ts
@@ -1,0 +1,61 @@
+import { Component, OnInit } from '@angular/core';
+import { FormArray, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { Rocket } from '../rocket.model';
+import { RocketService } from '../rocket.service';
+import { switchMap, take, tap } from 'rxjs/operators';
+import { FlightService } from '../flight.service';
+
+@Component({
+  selector: 'fmr-flight-new',
+  templateUrl: './flight-new.component.html',
+  styleUrls: ['./flight-new.component.scss']
+})
+export class FlightNewComponent implements OnInit {
+  flightForm: FormGroup;
+  rocket$ = this.route.paramMap.pipe(
+    tap(params => this.rocketId = params.get('rocketId')),
+    switchMap((params) => this.rocketService.getRocket(params.get('rocketId')))
+  );
+
+  private rocketId: string;
+
+  constructor(
+    fb: FormBuilder,
+    private rocketService: RocketService,
+    private route: ActivatedRoute,
+    private router: Router,
+    private flightService: FlightService
+  ) {
+    this.flightForm = fb.group({
+      date: ['', Validators.required],
+      motors: fb.array([new FormControl('')]),
+      notes: '',
+      altitude: ''
+    });
+  }
+
+  ngOnInit(): void {}
+
+  get motors(): FormArray {
+    return this.flightForm.get('motors') as FormArray;
+  }
+
+  addMotor(): void {
+    this.motors.push(new FormControl(''));
+  }
+
+  removeMotor(index: number): void {
+    if (this.motors.length <= 1) { return; }
+    this.motors.removeAt(index);
+  }
+
+  createFlight(): void {
+    this.flightService.createFlight(this.rocketId, this.flightForm.value).subscribe(() => {
+      this.router.navigate(['/rockets', this.rocketId], {
+        replaceUrl: true
+      })
+    });
+  }
+}

--- a/apps/fly-my-rockets/src/app/rockets/flight.service.spec.ts
+++ b/apps/fly-my-rockets/src/app/rockets/flight.service.spec.ts
@@ -1,0 +1,24 @@
+import { FlightService } from './flight.service';
+
+describe('FlightService', () => {
+  let service: FlightService;
+  let afAuth;
+  let db;
+  let doc;
+  let update;
+
+  beforeEach(() => {
+    afAuth = {};
+    update = jest.fn();
+    doc = jest.fn().mockReturnValue({ update });
+    db = { collection: jest.fn().mockReturnValue({ doc }) }
+    service = new FlightService(
+      afAuth,
+      db
+    );
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/apps/fly-my-rockets/src/app/rockets/flight.service.ts
+++ b/apps/fly-my-rockets/src/app/rockets/flight.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { AngularFireAuth } from '@angular/fire/auth';
+import { AngularFirestore } from '@angular/fire/firestore';
+import { Flight } from './rocket.model';
+import { from, Observable } from 'rxjs';
+import * as firebase from 'firebase/app';
+import FieldValue = firebase.firestore.FieldValue;
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FlightService {
+  constructor(
+    private afAuth: AngularFireAuth,
+    private db: AngularFirestore
+  ) { }
+
+  createFlight(rocketId: string, flight: Flight): Observable<void> {
+    return from(this.db.collection('rockets').doc(rocketId)
+      .update({ flights: FieldValue.arrayUnion(flight) }));
+  }
+}

--- a/apps/fly-my-rockets/src/app/rockets/rocket-show/rocket-show.component.html
+++ b/apps/fly-my-rockets/src/app/rockets/rocket-show/rocket-show.component.html
@@ -1,19 +1,18 @@
 <div *ngIf="rocket$ | async as rocket">
-  <h1>{{rocket.name}}</h1>
-
-  <h2>Flights</h2>
+  <h1>{{rocket.name}} Flights</h1>
   <mat-list>
     <mat-list-item *ngFor="let flight of flights$ | async">
       <img matListAvatar src="https://placekitten.com/50/50" alt="placekitten.com">
       <h3 matLine>{{flightDate(flight) | date}}</h3>
-      <span matLine>{{flight.motor}} | {{flight.altitude | number}}</span>
+      <span matLine>{{flight.motors?.length ? flight.motors.join(', ') : flight.motor}}</span>
+      <span matLine>{{flight.altitude | number}}</span>
       <button mat-icon-button (click)="removeFlight(flight)">
         <mat-icon>delete</mat-icon>
       </button>
     </mat-list-item>
   </mat-list>
 </div>
-<button mat-fab color="primary" class="fab-button"
-        (click)="openFlightDialog()">
+<a mat-fab color="primary" class="fab-button"
+        [routerLink]="['flights/new']">
   <mat-icon>add</mat-icon>
-</button>
+</a>

--- a/apps/fly-my-rockets/src/app/rockets/rocket-show/rocket-show.component.spec.ts
+++ b/apps/fly-my-rockets/src/app/rockets/rocket-show/rocket-show.component.spec.ts
@@ -1,5 +1,5 @@
 import { RocketShowComponent } from './rocket-show.component';
-import { Subject } from 'rxjs';
+import { of, Subject } from 'rxjs';
 
 describe('RocketShowComponent', () => {
   let component: RocketShowComponent;
@@ -8,7 +8,7 @@ describe('RocketShowComponent', () => {
   let dialog;
 
   beforeEach(() => {
-    rocketService = { removeFlight: jest.fn() };
+    rocketService = { removeFlight: jest.fn().mockReturnValue(of({})) };
     route = { paramMap: new Subject() };
     dialog = {};
     component = new RocketShowComponent(

--- a/apps/fly-my-rockets/src/app/rockets/rocket-show/rocket-show.component.ts
+++ b/apps/fly-my-rockets/src/app/rockets/rocket-show/rocket-show.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { RocketService } from '../rocket.service';
 import { ActivatedRoute } from '@angular/router';
-import { filter, switchMap, tap } from 'rxjs/operators';
+import { filter, map, switchMap, tap } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import { FlightDialogComponent } from '../dialogs/flight-dialog.component';
 import { Flight, Rocket } from '../rocket.model';
@@ -23,14 +23,7 @@ export class RocketShowComponent implements OnInit {
     tap(rocket => this.rocket = rocket)
   );
   flights$ = this.rocket$.pipe(
-    switchMap(rocket => {
-      const flightIds = rocket.flights;
-      if (flightIds?.length > 0) {
-        return this.rocketService.getFlights(flightIds);
-      } else {
-        return [];
-      }
-    })
+    map(rocket => rocket.flights)
   );
 
   constructor(
@@ -56,7 +49,10 @@ export class RocketShowComponent implements OnInit {
   }
 
   removeFlight(flight: Flight): void {
-    this.rocketService.removeFlight(this.rocketId, flight);
+    this.rocketService.removeFlight(this.rocketId, flight)
+      .subscribe(() => {}, (err) => {
+        console.error({ err });
+      });
   }
 
   flightDate(flight) {

--- a/apps/fly-my-rockets/src/app/rockets/rocket.service.ts
+++ b/apps/fly-my-rockets/src/app/rockets/rocket.service.ts
@@ -38,8 +38,17 @@ export class RocketService {
   }
 
   removeFlight(rocketId: string, flight: Flight) {
+    if (typeof flight === 'string') {
+      return from(this.db.collection('rockets').doc(rocketId).update({
+        flights: FieldValue.arrayRemove(flight)
+      }));
+    } else if (flight.id) {
+      return from(this.db.collection('rockets').doc(rocketId).update({
+        flights: FieldValue.arrayRemove(`/flights/${flight.id}`)
+      }));
+    }
     return from(this.db.collection('rockets').doc(rocketId).update({
-      flights: FieldValue.arrayRemove(`/flights/${flight.id}`)
+      flights: FieldValue.arrayRemove(flight)
     }))
   }
 

--- a/apps/fly-my-rockets/src/app/rockets/rockets-routing.module.ts
+++ b/apps/fly-my-rockets/src/app/rockets/rockets-routing.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { RocketListComponent } from './rocket-list/rocket-list.component';
 import { RocketShowComponent } from './rocket-show/rocket-show.component';
+import { FlightNewComponent } from './flight-new/flight-new.component';
 
 
 const routes: Routes = [
@@ -10,6 +11,9 @@ const routes: Routes = [
   },
   {
     path: ':rocketId', component: RocketShowComponent
+  },
+  {
+    path: ':rocketId/flights/new', component: FlightNewComponent
   }
 ];
 

--- a/apps/fly-my-rockets/src/app/rockets/rockets.module.ts
+++ b/apps/fly-my-rockets/src/app/rockets/rockets.module.ts
@@ -6,19 +6,24 @@ import { SharedModule } from '../shared/shared.module';
 import { RocketListComponent } from './rocket-list/rocket-list.component';
 import { RocketDialogComponent } from './dialogs/rocket-dialog.component';
 import { MatDialogModule } from '@angular/material/dialog';
-import { FormsModule } from '@angular/forms';
 import { RocketShowComponent } from './rocket-show/rocket-show.component';
 import { FlightDialogComponent } from './dialogs/flight-dialog.component';
+import { FlightNewComponent } from './flight-new/flight-new.component';
 
 
 @NgModule({
-  declarations: [RocketListComponent, RocketDialogComponent, RocketShowComponent, FlightDialogComponent],
+  declarations: [
+    RocketListComponent,
+    RocketDialogComponent,
+    RocketShowComponent,
+    FlightDialogComponent,
+    FlightNewComponent
+  ],
   imports: [
     CommonModule,
     RocketsRoutingModule,
     SharedModule,
     MatDialogModule,
-    FormsModule
   ],
   entryComponents: [RocketDialogComponent]
 })

--- a/apps/fly-my-rockets/src/app/shared/shared.module.ts
+++ b/apps/fly-my-rockets/src/app/shared/shared.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { MatButtonModule } from '@angular/material/button';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -36,6 +37,8 @@ const modules = [
   RouterModule,
   MatDatepickerModule,
   MatNativeDateModule,
+  FormsModule,
+  ReactiveFormsModule,
 ];
 
 @NgModule({

--- a/apps/fly-my-rockets/src/app/shared/shell/shell.component.scss
+++ b/apps/fly-my-rockets/src/app/shared/shell/shell.component.scss
@@ -52,4 +52,5 @@ i {
 .container {
   max-width: 920px;
   margin: 24px auto;
+  padding: 24px 12px;
 }


### PR DESCRIPTION
Need a way to add a new flight other than the dialog. Create a `flight-new` component and wire it up to add a flight to a rocket.

Also changed how flights are stored. Instead of a root flights collection with links in the rocket doc, embed the flights directly in the rocket document.

Originally I'd put the flights in a root collection in case we wanted to query across all flights to get stats. But with the collection group feature in Firebase now, we should be able to do this with flights embedded in the rocket.