### PR TITLE
Use more_vert icon for rocket options

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -3,11 +3,6 @@
   "projects": {
     "fly-my-rockets": {
       "projectType": "application",
-      "schematics": {
-        "@nrwl/angular:component": {
-          "style": "scss"
-        }
-      },
       "root": "apps/fly-my-rockets",
       "sourceRoot": "apps/fly-my-rockets/src",
       "prefix": "fmr",
@@ -221,6 +216,9 @@
     },
     "@nrwl/angular:library": {
       "unitTestRunner": "jest"
+    },
+    "@nrwl/angular:component": {
+      "style": "scss"
     }
   },
   "defaultProject": "fly-my-rockets"

--- a/apps/fly-my-rockets/src/app/rockets/rocket-show/rocket-show.component.html
+++ b/apps/fly-my-rockets/src/app/rockets/rocket-show/rocket-show.component.html
@@ -4,15 +4,19 @@
       <mat-card-title>{{rocket.name}}</mat-card-title>
     </mat-card-header>
     <img mat-card-image *ngIf="rocketPhotoUrl$ | async as photoUrl" [src]="photoUrl" [alt]="rocket.name">
-    <mat-card-actions align="end">
-      <button mat-icon-button [matMenuTriggerFor]="rocketEdit">
+    <mat-card-actions>
+      <button mat-button (click)="openRocketDialog(rocket)">
+        Edit
+      </button>
+      <button mat-button (click)="removePhoto()" *ngIf="rocket.photos && rocket.photos.length > 0">
+        Remove Photo
+      </button>
+      <button mat-icon-button [matMenuTriggerFor]="rocketMore" class="float-right">
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-card-actions>
   </mat-card>
-  <mat-menu #rocketEdit="matMenu">
-    <button mat-menu-item (click)="openRocketDialog(rocket)">Edit Details</button>
-    <button mat-menu-item (click)="removePhoto()" *ngIf="rocket.photos && rocket.photos.length > 0">Remove Photo</button>
+  <mat-menu #rocketMore="matMenu">
     <button mat-menu-item (click)="confirmDelete()">Delete Rocket</button>
   </mat-menu>
 

--- a/apps/fly-my-rockets/src/app/rockets/rocket-show/rocket-show.component.html
+++ b/apps/fly-my-rockets/src/app/rockets/rocket-show/rocket-show.component.html
@@ -4,14 +4,16 @@
       <mat-card-title>{{rocket.name}}</mat-card-title>
     </mat-card-header>
     <img mat-card-image *ngIf="rocketPhotoUrl$ | async as photoUrl" [src]="photoUrl" [alt]="rocket.name">
-    <mat-card-actions>
-      <button mat-button [matMenuTriggerFor]="rocketEdit">Edit</button>
-      <button mat-button color="warn" (click)="deleteRocket()">Delete</button>
+    <mat-card-actions align="end">
+      <button mat-icon-button [matMenuTriggerFor]="rocketEdit">
+        <mat-icon>more_vert</mat-icon>
+      </button>
     </mat-card-actions>
   </mat-card>
   <mat-menu #rocketEdit="matMenu">
-    <button mat-menu-item (click)="openRocketDialog(rocket)">Details</button>
+    <button mat-menu-item (click)="openRocketDialog(rocket)">Edit Details</button>
     <button mat-menu-item (click)="removePhoto()" *ngIf="rocket.photos && rocket.photos.length > 0">Remove Photo</button>
+    <button mat-menu-item (click)="confirmDelete()">Delete Rocket</button>
   </mat-menu>
 
   <h2>Flights</h2>

--- a/apps/fly-my-rockets/src/app/rockets/rocket-show/rocket-show.component.scss
+++ b/apps/fly-my-rockets/src/app/rockets/rocket-show/rocket-show.component.scss
@@ -14,3 +14,7 @@
   max-width: 350px;
   margin: 0 auto 24px auto;
 }
+
+.float-right {
+  float: right;
+}

--- a/apps/fly-my-rockets/src/app/rockets/rocket-show/rocket-show.component.spec.ts
+++ b/apps/fly-my-rockets/src/app/rockets/rocket-show/rocket-show.component.spec.ts
@@ -1,5 +1,7 @@
-import { RocketShowComponent } from './rocket-show.component';
+import { fakeAsync, tick } from '@angular/core/testing';
 import { of, Subject } from 'rxjs';
+import { RocketShowComponent } from './rocket-show.component';
+import { AreYouSureComponent } from '../../shared/are-you-sure/are-you-sure.component';
 
 describe('RocketShowComponent', () => {
   let component: RocketShowComponent;
@@ -17,7 +19,7 @@ describe('RocketShowComponent', () => {
       updateRocket: jest.fn().mockReturnValue(of({}))
     };
     route = { paramMap: new Subject() };
-    router = { navigate: jest.fn() };
+    router = { navigate: jest.fn().mockReturnValue(Promise.resolve()) };
     dialogAfterClosed = new Subject();
     dialog = {
       open: jest.fn().mockReturnValue({
@@ -41,14 +43,22 @@ describe('RocketShowComponent', () => {
     });
   });
 
-  describe('deleteRocket', () => {
-    it('deletes the rocket and navigates back to rockets', () => {
-      component.deleteRocket();
-      expect(rocketService.deleteRocket).toHaveBeenCalled();
+  describe('confirmDelete', () => {
+    it('opens the confirm dialog', fakeAsync(() => {
+      component.confirmDelete();
+      expect(dialog.open).toHaveBeenCalledWith(AreYouSureComponent, {
+        data: {
+          message: 'Are you sure you want to delete this rocket?',
+          yesColor: 'warn'
+        }
+      });
+      dialogAfterClosed.next(true);
+      tick();
       expect(router.navigate).toHaveBeenCalledWith(['/rockets'], {
         replaceUrl: true
       });
-    });
+      expect(rocketService.deleteRocket).toHaveBeenCalledWith(undefined);
+    }));
   });
 
   describe('openRocketDialog', () => {

--- a/apps/fly-my-rockets/src/app/rockets/rocket-show/rocket-show.component.spec.ts
+++ b/apps/fly-my-rockets/src/app/rockets/rocket-show/rocket-show.component.spec.ts
@@ -20,11 +20,9 @@ describe('RocketShowComponent', () => {
     router = { navigate: jest.fn() };
     dialogAfterClosed = new Subject();
     dialog = {
-      open: jest
-        .fn()
-        .mockReturnValue({
-          afterClosed: jest.fn().mockReturnValue(dialogAfterClosed)
-        })
+      open: jest.fn().mockReturnValue({
+        afterClosed: jest.fn().mockReturnValue(dialogAfterClosed)
+      })
     };
     storage = { ref: jest.fn() };
     component = new RocketShowComponent(

--- a/apps/fly-my-rockets/src/app/rockets/rocket-show/rocket-show.component.ts
+++ b/apps/fly-my-rockets/src/app/rockets/rocket-show/rocket-show.component.ts
@@ -10,6 +10,7 @@ import { Flight, Rocket } from '../rocket.model';
 import { FlightDialogComponent } from '../dialogs/flight-dialog/flight-dialog.component';
 import { RocketDialogComponent } from '../dialogs/rocket-dialog/rocket-dialog.component';
 import { rocketPhotoRef, ThumbnailSizes } from '../functions/rocket-photo-ref';
+import { AreYouSureComponent } from '../../shared/are-you-sure/are-you-sure.component';
 
 @Component({
   selector: 'fmr-rocket-show',
@@ -137,9 +138,18 @@ export class RocketShowComponent {
     );
   }
 
-  deleteRocket(): void {
-    this.rocketService.deleteRocket(this.rocketId).subscribe(() => {
-      this.router.navigate(['/rockets'], { replaceUrl: true });
+  confirmDelete(): void {
+    const dialogRef = this.dialog.open(AreYouSureComponent, {
+      data: {
+        message: 'Are you sure you want to delete this rocket?',
+        yesColor: 'warn'
+      }
+    });
+
+    dialogRef.afterClosed().subscribe(confirm => {
+      if (confirm) {
+        this.deleteRocket();
+      }
     });
   }
 
@@ -160,5 +170,11 @@ export class RocketShowComponent {
       .subscribe(() => {
         this.rocketUpdated$.next();
       });
+  }
+
+  private deleteRocket(): void {
+    this.router.navigate(['/rockets'], { replaceUrl: true }).then(() => {
+      this.rocketService.deleteRocket(this.rocketId).subscribe();
+    });
   }
 }

--- a/apps/fly-my-rockets/src/app/rockets/rockets.module.ts
+++ b/apps/fly-my-rockets/src/app/rockets/rockets.module.ts
@@ -5,7 +5,6 @@ import { RocketsRoutingModule } from './rockets-routing.module';
 import { SharedModule } from '../shared/shared.module';
 import { RocketListComponent } from './rocket-list/rocket-list.component';
 import { RocketDialogComponent } from './dialogs/rocket-dialog/rocket-dialog.component';
-import { MatDialogModule } from '@angular/material/dialog';
 import { RocketShowComponent } from './rocket-show/rocket-show.component';
 import { FlightDialogComponent } from './dialogs/flight-dialog/flight-dialog.component';
 import { FlightNewComponent } from './flight-new/flight-new.component';
@@ -18,7 +17,7 @@ import { FlightNewComponent } from './flight-new/flight-new.component';
     FlightDialogComponent,
     FlightNewComponent
   ],
-  imports: [CommonModule, RocketsRoutingModule, SharedModule, MatDialogModule],
+  imports: [CommonModule, RocketsRoutingModule, SharedModule],
   entryComponents: [RocketDialogComponent]
 })
 export class RocketsModule {}

--- a/apps/fly-my-rockets/src/app/rockets/rockets.module.ts
+++ b/apps/fly-my-rockets/src/app/rockets/rockets.module.ts
@@ -10,7 +10,6 @@ import { RocketShowComponent } from './rocket-show/rocket-show.component';
 import { FlightDialogComponent } from './dialogs/flight-dialog/flight-dialog.component';
 import { FlightNewComponent } from './flight-new/flight-new.component';
 
-
 @NgModule({
   declarations: [
     RocketListComponent,
@@ -19,12 +18,7 @@ import { FlightNewComponent } from './flight-new/flight-new.component';
     FlightDialogComponent,
     FlightNewComponent
   ],
-  imports: [
-    CommonModule,
-    RocketsRoutingModule,
-    SharedModule,
-    MatDialogModule,
-  ],
+  imports: [CommonModule, RocketsRoutingModule, SharedModule, MatDialogModule],
   entryComponents: [RocketDialogComponent]
 })
-export class RocketsModule { }
+export class RocketsModule {}

--- a/apps/fly-my-rockets/src/app/shared/are-you-sure/are-you-sure.component.html
+++ b/apps/fly-my-rockets/src/app/shared/are-you-sure/are-you-sure.component.html
@@ -1,0 +1,9 @@
+<mat-dialog-content>{{data.message}}</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="onNoClick()">
+    Cancel
+  </button>
+  <button mat-button [color]="data.yesColor" (click)="onYesClick()">
+    Delete
+  </button>
+</mat-dialog-actions>

--- a/apps/fly-my-rockets/src/app/shared/are-you-sure/are-you-sure.component.spec.ts
+++ b/apps/fly-my-rockets/src/app/shared/are-you-sure/are-you-sure.component.spec.ts
@@ -1,0 +1,27 @@
+import { AreYouSureComponent } from './are-you-sure.component';
+
+describe('AreYouSureComponent', () => {
+  let component: AreYouSureComponent;
+  let dialogRef;
+  let data;
+
+  beforeEach(() => {
+    dialogRef = { close: jest.fn() };
+    data = {};
+    component = new AreYouSureComponent(dialogRef, data);
+  });
+
+  describe('onNoClick', () => {
+    it('closes the dialog with false', () => {
+      component.onNoClick();
+      expect(dialogRef.close).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('onYesClick', () => {
+    it('closes the dialog with true', () => {
+      component.onYesClick();
+      expect(dialogRef.close).toHaveBeenCalledWith(true);
+    });
+  });
+});

--- a/apps/fly-my-rockets/src/app/shared/are-you-sure/are-you-sure.component.ts
+++ b/apps/fly-my-rockets/src/app/shared/are-you-sure/are-you-sure.component.ts
@@ -1,0 +1,22 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'fmr-are-you-sure',
+  templateUrl: './are-you-sure.component.html',
+  styleUrls: ['./are-you-sure.component.scss']
+})
+export class AreYouSureComponent {
+  constructor(
+    private dialogRef: MatDialogRef<AreYouSureComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: any
+  ) {}
+
+  onNoClick(): void {
+    this.dialogRef.close(false);
+  }
+
+  onYesClick(): void {
+    this.dialogRef.close(true);
+  }
+}

--- a/apps/fly-my-rockets/src/app/shared/shared.module.ts
+++ b/apps/fly-my-rockets/src/app/shared/shared.module.ts
@@ -17,10 +17,14 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatDialogModule } from '@angular/material/dialog';
 import { MaterialFileInputModule } from 'ngx-material-file-input';
 import { ShellComponent } from './shell/shell.component';
+import { AreYouSureComponent } from './are-you-sure/are-you-sure.component';
 
-const components = [ShellComponent];
+const entryComponents = [AreYouSureComponent];
+
+const components = [ShellComponent, ...entryComponents];
 
 const modules = [
   CommonModule,
@@ -40,6 +44,7 @@ const modules = [
   MatDatepickerModule,
   MatNativeDateModule,
   MatProgressBarModule,
+  MatDialogModule,
   MaterialFileInputModule,
   FormsModule,
   ReactiveFormsModule
@@ -48,6 +53,7 @@ const modules = [
 @NgModule({
   declarations: [...components],
   imports: [...modules],
-  exports: [...components, ...modules]
+  exports: [...components, ...modules],
+  entryComponents
 })
 export class SharedModule {}

--- a/apps/fly-my-rockets/src/app/shared/shell/shell.component.scss
+++ b/apps/fly-my-rockets/src/app/shared/shell/shell.component.scss
@@ -15,7 +15,7 @@
 
 .sidenav {
   width: 200px;
-  font-family: "Work Sans";
+  font-family: "Work Sans", sans-serif;
 }
 
 .sidenav .mat-toolbar {
@@ -52,5 +52,7 @@ i {
 .main-content {
   max-width: 920px;
   margin: 24px auto;
-  padding: 24px 12px;
+  // 68px bottom padding + 24px bottom margin to make sure nothing
+  // is obscured by the FAB
+  padding: 24px 12px 68px 12px;
 }


### PR DESCRIPTION
Adding the option to remove the rocket photo made the interaction kinda weird with the edit button triggering a menu. Move all the rocket actions (edit, remove photo, delete rocket) into a more_vert icon-triggered menu.

While we're in here, add a confirm dialog to delete the rocket.